### PR TITLE
Added support for ResearchPal Forked and Fluffys Research Trees queue function

### DIFF
--- a/Source/ResearchPause/Patches.cs
+++ b/Source/ResearchPause/Patches.cs
@@ -1,31 +1,87 @@
-﻿using RimWorld;
-using Verse;
-using System.Reflection;
+﻿using System.Reflection;
 using HarmonyLib;
+using RimWorld;
+using Verse;
 
 namespace ResearchPause
 {
     [StaticConstructorOnStartup]
     public static class Patches
     {
+        public static readonly string QueueModLoaded;
+
         static Patches()
         {
             var harmony = new Harmony("shrimpee.researchpause");
             harmony.PatchAll(Assembly.GetExecutingAssembly());
+
+            // Checks if ResearchPal Forked is loaded
+            if (ModLister.GetActiveModWithIdentifier("VinaLx.ResearchPalForked") != null)
+            {
+                QueueModLoaded = "ResearchPal";
+                var queueTraverse = Traverse.CreateWithType("ResearchPal.Queue");
+                if (!queueTraverse.Methods().Contains("TryStartNext"))
+                {
+                    Log.Warning(
+                        "[ResearchPause]: Could not find method in ResearchPal Forked to patch. Will not be able to use the queue-setting.");
+                    QueueModLoaded = null;
+                    return;
+                }
+
+                var tryStartNextMethodInfo =
+                    AccessTools.Method(AccessTools.TypeByName("ResearchPal.Queue"), "TryStartNext");
+                harmony.Patch(tryStartNextMethodInfo,
+                    postfix: new HarmonyMethod(typeof(Queue_TryStartNext), "Postfix"));
+                Log.Message(
+                    "[ResearchPause]: Patched ResearchPal Forked to be able to use the queue setting");
+                return;
+            }
+
+            // Checks if Fluffys Research Tree is loaded
+            if (ModLister.GetActiveModWithIdentifier("fluffy.researchtree") != null)
+            {
+                QueueModLoaded = "ReseachTree";
+                var queueTraverse = Traverse.CreateWithType("FluffyResearchTree.Queue");
+                if (!queueTraverse.Methods().Contains("TryStartNext"))
+                {
+                    Log.Warning(
+                        "[ResearchPause]: Could not find method in Research Tree to patch. Will not be able to use the queue-setting.");
+                    QueueModLoaded = null;
+                    return;
+                }
+
+                var tryStartNextMethodInfo =
+                    AccessTools.Method(AccessTools.TypeByName("FluffyResearchTree.Queue"), "TryStartNext");
+                harmony.Patch(tryStartNextMethodInfo,
+                    postfix: new HarmonyMethod(typeof(Queue_TryStartNext), "Postfix"));
+                Log.Message(
+                    "[ResearchPause]: Patched Research Tree to be able to use the queue setting");
+            }
         }
     }
 
     [HarmonyPatch(typeof(ResearchManager), "FinishProject")]
-    class Patch_ResearchManager_FinishProject
+    internal class Patch_ResearchManager_FinishProject
     {
-        static void Prefix(bool doCompletionDialog)
+        private static void Prefix(bool doCompletionDialog)
         {
-            bool pauseOnResearchFinished = LoadedModManager
+            if (string.IsNullOrEmpty(Patches.QueueModLoaded) && LoadedModManager
                 .GetMod<ResearchPauseMod>()
                 .GetSettings<ResearchPauseSettings>()
-                .pauseOnResearchFinished;
+                .onlyOnNoQueue)
+            {
+                return;
+            }
 
-            if (Current.ProgramState == ProgramState.Playing && pauseOnResearchFinished)
+            if (!LoadedModManager
+                .GetMod<ResearchPauseMod>()
+                .GetSettings<ResearchPauseSettings>()
+                .pauseOnResearchFinished)
+            {
+                return;
+            }
+
+            if (Current.ProgramState == ProgramState.Playing)
             {
                 TickManager_Helper.PauseIfUnpaused();
             }
@@ -33,16 +89,24 @@ namespace ResearchPause
     }
 
     [HarmonyPatch(typeof(Window), nameof(Window.PreOpen))]
-    class Patch_Window_PreOpen
+    internal class Patch_Window_PreOpen
     {
-        static void Prefix(Window __instance)
+        private static void Prefix(Window __instance)
         {
-            bool pauseOnResearchWindowOpen = LoadedModManager
+            if (Patches.QueueModLoaded == "ResearchPal")
+            {
+                return;
+            }
+
+            if (!LoadedModManager
                 .GetMod<ResearchPauseMod>()
                 .GetSettings<ResearchPauseSettings>()
-                .pauseOnResearchWindowOpen;
+                .pauseOnResearchWindowOpen)
+            {
+                return;
+            }
 
-            if (__instance is MainTabWindow_Research && pauseOnResearchWindowOpen)
+            if (__instance is MainTabWindow_Research || __instance.GetType().Name == "MainTabWindow_ResearchTree")
             {
                 TickManager_Helper.PauseIfUnpaused();
             }
@@ -50,18 +114,55 @@ namespace ResearchPause
     }
 
     [HarmonyPatch(typeof(Window), nameof(Window.PreClose))]
-    class Patch_Window_PreClose
+    internal class Patch_Window_PreClose
     {
-        static void Prefix(Window __instance)
+        private static void Prefix(Window __instance)
         {
-            bool pauseOnResearchWindowOpen = LoadedModManager
+            if (Patches.QueueModLoaded == "ResearchPal")
+            {
+                return;
+            }
+
+            if (!LoadedModManager
                 .GetMod<ResearchPauseMod>()
                 .GetSettings<ResearchPauseSettings>()
-                .pauseOnResearchWindowOpen;
+                .pauseOnResearchWindowOpen)
+            {
+                return;
+            }
 
-            if (__instance is MainTabWindow_Research && pauseOnResearchWindowOpen)
+            if (__instance is MainTabWindow_Research || __instance.GetType().Name == "MainTabWindow_ResearchTree")
             {
                 TickManager_Helper.UnpausedIfPaused();
+            }
+        }
+    }
+
+    public class Queue_TryStartNext
+    {
+        // Postfix that runs after ResearchTree Forked/Fluffys Research Trees function TryStartNext
+        // If the ResearchManager has no active project after its run there was nothing in the queue and we can pause if needed
+        public static void Postfix()
+        {
+            if (!LoadedModManager
+                .GetMod<ResearchPauseMod>()
+                .GetSettings<ResearchPauseSettings>()
+                .onlyOnNoQueue)
+            {
+                return;
+            }
+
+            if (!LoadedModManager
+                .GetMod<ResearchPauseMod>()
+                .GetSettings<ResearchPauseSettings>()
+                .pauseOnResearchFinished)
+            {
+                return;
+            }
+
+            if (Find.ResearchManager.currentProj == null)
+            {
+                TickManager_Helper.PauseIfUnpaused();
             }
         }
     }

--- a/Source/ResearchPause/ResearchPauseMod.cs
+++ b/Source/ResearchPause/ResearchPauseMod.cs
@@ -1,32 +1,46 @@
-﻿using RimWorld;
+﻿using UnityEngine;
 using Verse;
-using System.Reflection;
-using HarmonyLib;
-using UnityEngine;
 
 namespace ResearchPause
 {
     public class ResearchPauseMod : Mod
     {
-        ResearchPauseSettings settings;
+        private readonly ResearchPauseSettings settings;
 
         public ResearchPauseMod(ModContentPack content) : base(content)
         {
-            this.settings = GetSettings<ResearchPauseSettings>();
+            settings = GetSettings<ResearchPauseSettings>();
         }
 
         public override void DoSettingsWindowContents(Rect inRect)
         {
-            Listing_Standard listingStandard = new Listing_Standard();
+            var listingStandard = new Listing_Standard();
             listingStandard.Begin(inRect);
             listingStandard.CheckboxLabeled(
                 "Automatically pause when a pawn finishes researching",
                 ref settings.pauseOnResearchFinished
             );
-            listingStandard.CheckboxLabeled(
-                "Automatically pause while Research window is open",
-                ref settings.pauseOnResearchWindowOpen
-            );
+            if (!string.IsNullOrEmpty(Patches.QueueModLoaded))
+            {
+                listingStandard.CheckboxLabeled(
+                    "Only pause on no queued research",
+                    ref settings.onlyOnNoQueue
+                );
+            }
+
+            if (Patches.QueueModLoaded == "ResearchPal")
+            {
+                listingStandard.Label(
+                    "Pausing when the research-window is shown can be activated in ResearchPal Forked mod-options.");
+            }
+            else
+            {
+                listingStandard.CheckboxLabeled(
+                    "Automatically pause while Research window is open",
+                    ref settings.pauseOnResearchWindowOpen
+                );
+            }
+
             listingStandard.End();
             base.DoSettingsWindowContents(inRect);
         }

--- a/Source/ResearchPause/ResearchPauseSettings.cs
+++ b/Source/ResearchPause/ResearchPauseSettings.cs
@@ -4,6 +4,7 @@ namespace ResearchPause
 {
     public class ResearchPauseSettings : ModSettings
     {
+        public bool onlyOnNoQueue = true;
         public bool pauseOnResearchFinished = true;
         public bool pauseOnResearchWindowOpen = true;
 
@@ -11,6 +12,7 @@ namespace ResearchPause
         {
             Scribe_Values.Look(ref pauseOnResearchFinished, "researchFinished", true);
             Scribe_Values.Look(ref pauseOnResearchWindowOpen, "researchWindowOpen", true);
+            Scribe_Values.Look(ref onlyOnNoQueue, "onlyOnNoQueue", true);
 
             base.ExposeData();
         }


### PR DESCRIPTION
I got a request of updating a similar mod, [Pause On Research](https://steamcommunity.com/sharedfiles/filedetails/?id=2068653614), but since this already was maintained Ill just notify the requestor about it instead.

The other mod however had a request that when using a research-tree mod that allows for queueing of projects, that it should only pause when there are no projects left.
So this PR will add support for that, with the appropriate mod-option.

It also adds support for pausing when showing the tree when using Fluffys ResearchTree as it overrides the window-type.
ResearchPal Forked already has its own setting for pausing so if that is loaded it will inform about that instead of showing the setting in this mod.

Hope you find it useful!